### PR TITLE
Update egg-t-modloader.json

### DIFF
--- a/game_eggs/terraria/tmodloader/egg-t-modloader.json
+++ b/game_eggs/terraria/tmodloader/egg-t-modloader.json
@@ -10,7 +10,7 @@
     "description": "tModLoader is essentially a mod that provides a way to load your own mods without having to work directly with Terraria's source code itself. This means you can easily make mods that are compatible with other people's mods, save yourself the trouble of having to decompile and recompile Terraria.exe, and escape from having to understand all of the obscure \"intricacies\" of Terraria's source code. It is made to work for Terraria 1.3+.",
     "features": null,
     "docker_images": {
-        "Dotnet 6": "ghcr.io\/parkervcp\/yolks:dotnet_6"
+        "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8"
     },
     "file_denylist": [],
     "startup": ".\/tModLoaderServer -ip 0.0.0.0 -port {{SERVER_PORT}} -maxplayers {{MAX_PLAYERS}} -difficulty {{DIFFICULTY}} -password \"{{SERVER_PASSWORD}}\" -motd \"{{MOTD}}\" -lang {{LANGUAGE}} -world ~\/saves\/Worlds\/{{WORLD_NAME}}.wld -worldname {{WORLD_NAME}} -autocreate {{WORLD_SIZE}} -savedirectory ~\/ -tmlsavedirectory ~\/saves -modpath ~\/mods",


### PR DESCRIPTION
Current version crashes on startup because it now needs .net 8. Switching the image to use parkers .net 8 image seems to work.

# Description

Switched .NET docker image from .NET 6 to .NET 8

## Checklist for all submissions

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: 