### PR TITLE
Update egg-vanilla-bedrock.json install script to support Mojang's ne…

### DIFF
--- a/game_eggs/minecraft/bedrock/bedrock/egg-vanilla-bedrock.json
+++ b/game_eggs/minecraft/bedrock/bedrock/egg-vanilla-bedrock.json
@@ -1,19 +1,19 @@
 {
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PTERODACTYL PANEL - PTERODACTYL.IO",
     "meta": {
-        "version": "PTDL_v1",
+        "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2022-01-22T05:42:40-05:00",
+    "exported_at": "2024-11-29T22:31:23+05:30",
     "name": "Vanilla Bedrock",
     "author": "parker@parkervcp.com",
     "description": "Bedrock Edition (also known as the Bedrock Version, Bedrock Codebase, Bedrock Engine or just Bedrock) refers to the multi-platform family of editions of Minecraft developed by Mojang AB, Microsoft Studios, 4J Studios, and SkyBox Labs. Prior to this term, as the engine originated with Pocket Edition, this entire product family was referred to as \"Pocket Edition\", \"MCPE\", or \"Pocket\/Windows 10 Edition\".",
     "features": [
         "pid_limit"
     ],
-    "images": [
-        "ghcr.io\/parkervcp\/yolks:debian"
-    ],
+    "docker_images": {
+        "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
+    },
     "file_denylist": [],
     "startup": ".\/bedrock_server",
     "config": {
@@ -24,8 +24,8 @@
     },
     "scripts": {
         "installation": {
-            "script": "#!\/bin\/bash\r\n\r\napt update\r\napt install -y zip unzip wget curl\r\n\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\/\r\nfi\r\n\r\ncd \/mnt\/server\r\n\r\n# Minecraft CDN Akamai blocks script user-agents\r\nRANDVERSION=$(echo $((1 + $RANDOM % 4000)))\r\n\r\nif [ -z \"${BEDROCK_VERSION}\" ] || [ \"${BEDROCK_VERSION}\" == \"latest\" ]; then\r\n    echo -e \"\\n Downloading latest Bedrock server\"\r\n    curl -L -A \"Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/90.0.$RANDVERSION.212 Safari\/537.36\" -H \"Accept-Language: en\" -H \"Accept-Encoding: gzip, deflate\" -o versions.html.gz https:\/\/www.minecraft.net\/en-us\/download\/server\/bedrock\r\n    DOWNLOAD_URL=$(zgrep -o 'https:\/\/minecraft.azureedge.net\/bin-linux\/[^\"]*' versions.html.gz)\r\nelse \r\n    echo -e \"\\n Downloading ${BEDROCK_VERSION} Bedrock server\"\r\n    DOWNLOAD_URL=https:\/\/minecraft.azureedge.net\/bin-linux\/bedrock-server-$BEDROCK_VERSION.zip\r\nfi\r\n\r\nDOWNLOAD_FILE=$(echo ${DOWNLOAD_URL} | cut -d\"\/\" -f5) # Retrieve archive name\r\n\r\necho -e \"backing up config files\"\r\nrm *.bak versions.html.gz\r\ncp server.properties server.properties.bak\r\ncp permissions.json permissions.json.bak\r\ncp whitelist.json whitelist.json.bak\r\n\r\necho -e \"Downloading files from: $DOWNLOAD_URL\"\r\n\r\ncurl -L -A \"Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/90.0.$RANDVERSION.212 Safari\/537.36\" -H \"Accept-Language: en\" -o $DOWNLOAD_FILE $DOWNLOAD_URL\r\n\r\necho -e \"Unpacking server files\"\r\nunzip -o $DOWNLOAD_FILE\r\n\r\necho -e \"Cleaning up after installing\"\r\nrm $DOWNLOAD_FILE\r\n\r\necho -e \"restoring backup config files - on first install there will be file not found errors which you can ignore.\"\r\ncp -rf server.properties.bak server.properties\r\ncp -rf permissions.json.bak permissions.json\r\ncp -rf whitelist.json.bak whitelist.json\r\n\r\nchmod +x bedrock_server\r\n\r\necho -e \"Install Completed\"",
-            "container": "debian:buster-slim",
+            "script": "#!\/bin\/bash\r\n\r\n# Update and install necessary utilities\r\napt update\r\napt install -y zip unzip wget curl\r\n\r\n# Ensure server directory exists\r\nif [ ! -d \/mnt\/server\/ ]; then\r\n    mkdir \/mnt\/server\/\r\nfi\r\n\r\n# Navigate to the server directory\r\ncd \/mnt\/server\r\n\r\n# Randomized User-Agent for download requests\r\nRANDVERSION=$(echo $((1 + $RANDOM % 4000)))\r\n\r\n# Check if the BEDROCK_VERSION variable is set or if 'latest' is specified\r\nif [ -z \"${BEDROCK_VERSION}\" ] || [ \"${BEDROCK_VERSION}\" == \"latest\" ]; then\r\n    echo -e \"\\nDownloading latest Bedrock server\"\r\n    # Fetch the versions page and compress it to `versions.html.gz`\r\n    curl -L -A \"Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/90.0.$RANDVERSION.212 Safari\/537.36\" -H \"Accept-Language: en\" -H \"Accept-Encoding: gzip, deflate\" -o versions.html.gz https:\/\/www.minecraft.net\/en-us\/download\/server\/bedrock\r\n    # Extract the correct URL for the new CDN structure\r\n    DOWNLOAD_URL=$(zgrep -o 'https:\/\/www.minecraft.net\/bedrockdedicatedserver\/bin-linux\/bedrock-server-[0-9\\.]*\\.zip' versions.html.gz)\r\nelse\r\n    echo -e \"\\nDownloading ${BEDROCK_VERSION} Bedrock server\"\r\n    # Use the specific version with the updated URL format\r\n    DOWNLOAD_URL=\"https:\/\/www.minecraft.net\/bedrockdedicatedserver\/bin-linux\/bedrock-server-${BEDROCK_VERSION}.zip\"\r\nfi\r\n\r\n\r\n# Get the file name from the URL\r\nDOWNLOAD_FILE=$(echo ${DOWNLOAD_URL} | cut -d\"\/\" -f5) # Extracts the archive name from the URL\r\n\r\n# Backing up current config files\r\necho -e \"Backing up config files\"\r\nrm *.bak versions.html.gz\r\ncp server.properties server.properties.bak\r\ncp permissions.json permissions.json.bak\r\ncp allowlist.json allowlist.json.bak\r\n\r\n# Downloading the server files\r\necho -e \"Downloading files from: $DOWNLOAD_URL\"\r\ncurl -L -A \"Mozilla\/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit\/537.36 (KHTML, like Gecko) Chrome\/90.0.$RANDVERSION.212 Safari\/537.36\" -H \"Accept-Language: en\" -o $DOWNLOAD_FILE $DOWNLOAD_URL\r\n\r\n# Unpacking the server files\r\necho -e \"Unpacking server files\"\r\nunzip -o $DOWNLOAD_FILE\r\n\r\n# Cleaning up after installation\r\necho -e \"Cleaning up\"\r\nrm $DOWNLOAD_FILE\r\n\r\n# Restoring backup config files\r\necho -e \"Restoring backup config files - On first install, there may be file not found errors which can be ignored.\"\r\ncp -rf server.properties.bak server.properties\r\ncp -rf permissions.json.bak permissions.json\r\ncp -rf allowlist.json.bak allowlist.json\r\n\r\n# Ensure the server is executable\r\nchmod +x bedrock_server\r\n\r\n# Final message\r\necho -e \"Install Completed\"",
+            "container": "ghcr.io\/parkervcp\/installers:debian",
             "entrypoint": "bash"
         }
     },
@@ -37,7 +37,8 @@
             "default_value": "latest",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20"
+            "rules": "required|string|max:20",
+            "field_type": "text"
         },
         {
             "name": "ld lib path",
@@ -46,7 +47,8 @@
             "default_value": ".",
             "user_viewable": false,
             "user_editable": false,
-            "rules": "required|string|max:20"
+            "rules": "required|string|max:20",
+            "field_type": "text"
         },
         {
             "name": "Server Name",
@@ -55,7 +57,8 @@
             "default_value": "Bedrock Dedicated Server",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:50"
+            "rules": "required|string|max:50",
+            "field_type": "text"
         },
         {
             "name": "Gamemode",
@@ -64,7 +67,8 @@
             "default_value": "survival",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:survival,creative,adventure"
+            "rules": "required|string|in:survival,creative,adventure",
+            "field_type": "text"
         },
         {
             "name": "Difficulty",
@@ -73,7 +77,8 @@
             "default_value": "easy",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:peaceful,easy,normal,hard"
+            "rules": "required|string|in:peaceful,easy,normal,hard",
+            "field_type": "text"
         },
         {
             "name": "Allow cheats",
@@ -82,7 +87,8 @@
             "default_value": "false",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|in:true,false"
+            "rules": "required|string|in:true,false",
+            "field_type": "text"
         }
     ]
 }


### PR DESCRIPTION
# Description

This update adjusts the egg-vanilla-bedrock.json installation script to align with Mojang's recent changes to their CDN and download URLs. The script now uses the new base URL (https://www.minecraft.net/bedrockdedicatedserver/bin-linux/) to download the Bedrock server files.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done. You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?: